### PR TITLE
Bugfix/images

### DIFF
--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -27,7 +27,7 @@ function App(): ReactElement {
     setIsLoading(true);
     const corsAnywhere: string = `https://cors-anywhere.herokuapp.com/`;
     const modifiedSearchTerm: string = searchTerm.split(" ").join("+");
-    const url = `${corsAnywhere}https://tastedive.com/api/similar?q=${modifiedSearchTerm}&verbose=1&k=372838-DavePern-7J59GJ8D&limit=5`;
+    const url = `${corsAnywhere}https://tastedive.com/api/similar?q=${modifiedSearchTerm}&verbose=1&k=372838-DavePern-7J59GJ8D`;
 
     const data = await fetch(url)
       .then((response) =>

--- a/src/Components/Result/Result.css
+++ b/src/Components/Result/Result.css
@@ -8,5 +8,6 @@
 .result-card-image {
   width: 140px;
   height: 200px;
-  background: #aaa;
+  background: none;
+  object-fit: contain;
 }

--- a/src/Components/Result/Result.tsx
+++ b/src/Components/Result/Result.tsx
@@ -45,10 +45,8 @@ const Result = (props: Props) => {
   return (
     <Link to={link}>
       <div className="Result">
-        {/* <div className="fakeImage"> */}
         <h3>{Name}</h3>
         <img src={imageUrl} alt={Name} className="result-card-image" />
-        {/* </div> */}
       </div>
     </Link>
   );

--- a/src/Components/Result/Result.tsx
+++ b/src/Components/Result/Result.tsx
@@ -2,35 +2,52 @@ import React, { useState, useEffect } from "react";
 import { searchResult } from "../../types";
 import "./Result.css";
 import { Link } from "react-router-dom";
-import wiki from 'wikijs'
+import wiki from "wikijs";
 
 interface Props {
   data: searchResult;
 }
 
 const Result = (props: Props) => {
-  const { Name } = props.data;
+  const { Name, wUrl } = props.data;
   const link = `/title/${Name.replace(/\s/g, "+")}`;
-    
-  const [ imageUrl, setImageUrl ] = useState('')
+
+  const [imageUrl, setImageUrl] = useState("");
 
   const getImage = async (): Promise<void> => {
-    const url = await wiki().page(props.data.Name)
-    .then(page => page.mainImage())
-    .catch(err => console.error(err))
-    if (url) setImageUrl(url) 
-  }
+    try {
+      const title = decodeURI(`${wUrl.split("/").pop()}`);
 
-  useEffect(() => { 
-    getImage()
-  })
+      const url = await wiki()
+        .page(title)
+        .then((page) => page.mainImage())
+        .catch((err) => console.error(err));
+
+      if (url) setImageUrl(url);
+    } catch {
+      try {
+        const url = await wiki()
+          .page(Name)
+          .then((page) => page.mainImage())
+          .catch((err) => console.error(err));
+
+        if (url) setImageUrl(url);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  };
+
+  useEffect(() => {
+    getImage();
+  });
 
   return (
     <Link to={link}>
       <div className="Result">
         {/* <div className="fakeImage"> */}
-          <h3>{Name}</h3>
-          <img src={imageUrl} alt="result" className="result-card-image"/>
+        <h3>{Name}</h3>
+        <img src={imageUrl} alt={Name} className="result-card-image" />
         {/* </div> */}
       </div>
     </Link>

--- a/src/Components/SearchForm/SearchForm.tsx
+++ b/src/Components/SearchForm/SearchForm.tsx
@@ -10,8 +10,6 @@ const SearchForm: React.FC<Props> = (props: Props) => {
   const [query, setQuery] = useState("");
   return (
     <form className="SearchForm" onSubmit={(e) => e.preventDefault()}>
-      {/* placeholder is just for tests, you can change it if you like (just update the tests, too) */}
-
       <input
         placeholder="Search for a title"
         onChange={(e) => setQuery(e.target.value)}


### PR DESCRIPTION
#### What's this PR do?
This PR fixes some issues that would occur sometimes, as well as formatting the images a little better.
#### Where should the reviewer start?
Result.tsx
#### How should this be manually tested?
Search a variety of media, films, music, tv shows, etc. Almost everything should have an image (and the image shouldn't be squashed or stretched, although it may be a bit small)
#### Any background context you want to provide?
Searching wikipedia articles by the title of the media can sometimes lead to a disambiguation page being pulled up, instead of the article. If we take off the last bit of the wURL that the tastedive API gives us, and parse it somehow (removing those funky %20 things and replacing them with their unicode counterparts) we can get the exact page we want nearly every time.
#### What are the relevant tickets?
- 
#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2020-05-30 at 10 57 15" src="https://user-images.githubusercontent.com/23513486/83334525-639ec400-a264-11ea-9df9-fda700d0477a.png">
#### Questions:
-