### PR TITLE
Feature/finishtitlepage

### DIFF
--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -9,10 +9,6 @@ import { findSimilar } from "../../apiCalls";
 import FavoritesList from "../FavoritesPage/FavoritesList";
 import TitlePage from "../TitlePage/TitlePage";
 
-//state should be empty
-//eventually state will hold the user's search term
-//need another method in this function maybe that will be passed to search form
-
 function App(): ReactElement {
   const [results, setResults] = useState<searchResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -41,9 +37,9 @@ function App(): ReactElement {
     //needs to do a fetch call based on the search term and console log results
     setError(null);
     setIsLoading(true);
-    const corsAnywhere: string = `https://cors-anywhere.herokuapp.com/`;
-    const modifiedSearchTerm: string = searchTerm.split(" ").join("+");
-    const url = `${corsAnywhere}https://tastedive.com/api/similar?q=${modifiedSearchTerm}&verbose=1&k=372838-DavePern-7J59GJ8D&limit=5`;
+    // const corsAnywhere: string = `https://cors-anywhere.herokuapp.com/`;
+    // const modifiedSearchTerm: string = searchTerm.split(" ").join("+");
+    // const url = `${corsAnywhere}https://tastedive.com/api/similar?q=${modifiedSearchTerm}&verbose=1&k=372838-DavePern-7J59GJ8D&limit=5`;
 
     // const data = await fetch(url)
     // let data = await apiCalls(searchTerm);
@@ -51,11 +47,13 @@ function App(): ReactElement {
       .then((response) =>
         response.ok ? response.json() : setError(response.status)
       )
-      .then((response) => 
-        response ? setResults([...response.Similar.Info, ...response.Similar.Results]) : null
+      .then((response) =>
+        response
+          ? setResults([...response.Similar.Info, ...response.Similar.Results])
+          : null
       )
       .catch((err) => setError(err));
-  
+
     setIsLoading(false);
   };
 
@@ -82,21 +80,24 @@ function App(): ReactElement {
           />
         </Route>
         <Route path="/search/:query"></Route>
-        {results && (
-          <Route
-            path="/title/:name"
-            render={({ match }) => {
-              const { name } = match.params;
-              const regularName = name.split("+").join(" ");
-              console.log(results);
-              const matchedName: searchResult | any = results.find((result) =>
-                result.Name.includes(regularName)
-              );
-              console.log(matchedName);
-              return <TitlePage item={matchedName} />;
-            }}
-          ></Route>
-        )}
+        <Route
+    
+          path="/title/:name"
+          render={({ match }) => {
+            const { name } = match.params;
+            //everything in here is making this run twice. Why? 
+            // const regularName = name.split("+").join(" ");
+            // const matchedName: searchResult | any = results.find((result) =>
+            //   result.Name.includes(regularName)
+            // );
+            // console.log(matchedName);
+            // console.log(results, isLoading, error, favorites)
+            return <TitlePage url={name} />;
+
+            // may need to keep matchedName and just tweak it
+            //
+          }}
+        ></Route>
         <Route exact path="/">
           <SearchForm searchTerm={searchTerm} />
           {isLoading && <p>Finding matches...</p>}

--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -81,18 +81,26 @@ function App(): ReactElement {
         </Route>
         <Route path="/search/:query"></Route>
         <Route
-    
           path="/title/:name"
           render={({ match }) => {
             const { name } = match.params;
-            //everything in here is making this run twice. Why? 
+            const randomNum = Math.round(Math.random() * 1000000);
+            //everything in here is making this run twice. Why?
             // const regularName = name.split("+").join(" ");
             // const matchedName: searchResult | any = results.find((result) =>
             //   result.Name.includes(regularName)
             // );
             // console.log(matchedName);
             // console.log(results, isLoading, error, favorites)
-            return <TitlePage url={name} />;
+            return (
+              <TitlePage
+                url={name}
+                key={randomNum}
+                toggleFavorite={toggleFavorite}
+                favorites={favorites}
+
+              />
+            );
 
             // may need to keep matchedName and just tweak it
             //

--- a/src/Components/RelatedItem/RelatedItem.css
+++ b/src/Components/RelatedItem/RelatedItem.css
@@ -1,0 +1,13 @@
+.small-image-placeholder {
+    background-color: white;
+    width: 140px;
+    height: 200px;
+}
+
+.related-item {
+    margin: 1%;
+}
+
+.related-item-title {
+    margin-bottom: 6%;
+}

--- a/src/Components/RelatedItem/RelatedItem.tsx
+++ b/src/Components/RelatedItem/RelatedItem.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import './RelatedItem.css'
+import {searchResult} from '../../types'
+import { Link } from "react-router-dom";
+
+
+interface Props {
+    Name: string;
+    Type: string;
+    wTeaser: string;
+    wUrl: string;
+    yUrl: string;
+    yID: string;
+}
+
+const RelatedItem: React.FC<searchResult> = (props: Props) => {
+
+    return(
+        <section className="related-item">
+            <Link to={`${props.Name.split(' ').join('+')}`}>
+            <h5 className="related-item-title">{props.Name}</h5>
+            <figure className="small-image-placeholder">
+            </figure>
+            </Link>
+        </section>
+    )
+
+}
+
+export default RelatedItem;
+

--- a/src/Components/ResultsPage/ResultsPage.tsx
+++ b/src/Components/ResultsPage/ResultsPage.tsx
@@ -19,19 +19,18 @@ const ResultsPage = (props: Props) => {
       type={r.Type}
     />
   ));
-  const searchItem = results.shift()
-
+  const searchItem = results.shift();
 
   return (
     <div className="ResultsPage">
       <section className="search-item-display">
-         <h2>Main Title</h2>
-         {searchItem}
+        <h2>Main Title</h2>
+        {searchItem}
       </section>
-       <h2>Related Titles</h2>
-       {results}
+      <h2>Related Titles</h2>
+      {results}
     </div>
-  )
+  );
 };
 
 export default ResultsPage;

--- a/src/Components/TitlePage/TitlePage.css
+++ b/src/Components/TitlePage/TitlePage.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 90%;
+  height: 90%;
   margin: 2% auto;
   background: #473E40;
   border-radius: 5px;
@@ -13,11 +14,18 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 30%;
   /* justify-content: space-between; */
+}
+
+.title-favorite-button {
+  position: relative;
+  margin: 0;
 }
 
 .title-detailed-info {
   margin: 5%;
+  width: 70%;
   text-align: left;
 }
 
@@ -44,6 +52,20 @@
   width: 100px;
 }
 
+.all-related-items {
+  display: flex;
+  flex-direction: row;
+  align-content: center;
+  margin: 2%;
+  padding: 1%;
+}
+
+.title-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+}
+
 @media all and (min-width: 600px) {
   .title-page {
     flex-direction: row;
@@ -51,10 +73,10 @@
     max-height: 85%;
   }
   .title-overview {
-    width: 40%;
+    width: 30%;
   }
   .title-detailed-info {
-    width: 40%;
+    width: 70%;
     overflow: scroll;
   }
 }

--- a/src/Components/TitlePage/TitlePage.css
+++ b/src/Components/TitlePage/TitlePage.css
@@ -4,7 +4,7 @@
   width: 90%;
   height: 90%;
   margin: 2% auto;
-  background: #473E40;
+  background: #473e40;
   border-radius: 5px;
   color: white;
 }
@@ -41,8 +41,8 @@
 
 .result-card-image-placeholder {
   background-color: black;
-  width: 240px;
-  height: 300px;
+  width: 100%;
+  height: 55%;
   object-fit: contain;
   margin: 2% 0;
 }
@@ -63,7 +63,9 @@
 .title-header {
   display: flex;
   flex-direction: row;
-  justify-content: space-evenly;
+  justify-content: space-between;
+  position: relative;
+  width: 100%;
 }
 
 @media all and (min-width: 600px) {

--- a/src/Components/TitlePage/TitlePage.tsx
+++ b/src/Components/TitlePage/TitlePage.tsx
@@ -2,92 +2,37 @@ import React, { useState, useEffect } from "react";
 import { searchResult } from "../../types";
 import "./TitlePage.css";
 // import youtube from '../../../public/images/youtube_logo.png'
-import { findTitleInfo } from "../../apiCalls";
+import { findTitleInfo, getWikiImage } from "../../apiCalls";
 import { setConstantValue } from "typescript";
+import RelatedItem from "../RelatedItem/RelatedItem";
+import FavoriteButton from "../FavoriteButton/FavoriteButton";
 
 interface Props {
-  // item?: searchResult;
   url: string;
+  toggleFavorite: (id: string) => void;
+  favorites: string[];
 }
 
-//I'm trying to make a fetch call
-//based on the url, I want to make a fetch call to that endpoint of the api
-//it should then display the appropriate information on the page
-//the title page is being run twice
-//my fetch call was being run twice, too
-//I don't know how to use useeffect effectively
-
-//why is the fetch call sending so many requests? It sends at least two no matter what I do.
-//I don't get why I can't seem to add the results of the fetch call to state
-//should I just save it in a variable?
-// const FavoritesList = (props: Props) => {
-//   const [results, setResults] = useState<searchResult[]>([]);
-
-//   useEffect(() => {
-//     async function fetchData() {
-//       const { Similar } = await fetchFavorites(props.favorites);
-
-//       if (Similar) setResults(Similar.Info);
-//     }
-//     fetchData();
-//   }, [props.favorites]);
-
-//normally I would do this in a separate file but handle in component did mount, I think
-//then I would pass down the information as a prop
-//I would invoke the function on page load?
-//that doesn't make sense
-
 const TitlePage: React.FC<Props> = (props: Props) => {
-  // debugger;
-  // const actualTitle: string = props.name.split('+').join(' ')
-  const [results, setResults] = useState<searchResult[]>([]); // const [info, setInfo] = useState([]);
-  const [info, setInfo] = useState<searchResult[]>([]); // const [info, setInfo] = useState([]);
-  //don't need to set title
-  //do I really need to set state?
-  // setTitle(props.name.split('+').join(' '))
-  console.log("happening");
-  //do fetch call here?
-  //props.name only exists...when?
-  //props.name exists if you are not coming from the search results
-  console.log(props.url);
-  // console.log(title)
+  const [results, setResults] = useState<searchResult[]>([]);
+  const [info, setInfo] = useState<searchResult[]>([]);
+  const [img, setImg] = useState("");
 
-  // let results: {Results: object}[] = [];
-  // let info: {Info: object}[] = [];
+  console.log("happening");
+  console.log(props.url);
   useEffect(() => {
     async function retrieveInfo() {
-      const allData = await findTitleInfo(props.url)
-        // .then((response) => (response.ok ? response.json() : null))
-        .then((data) => {
-          if (data) {
-            // results.push(data.Similar.Results);
-            // info.push(...data.Similar.Info)
-            setResults(data.Similar.Results);
-            setInfo(data.Similar.Info);
-            return data;
-            // console.log(data.Similar.Results)
-          }
-        });
+      const allData = await findTitleInfo(props.url).then((data) => {
+        if (data) {
+          setResults(data.Similar.Results);
+          setInfo(data.Similar.Info);
+          return data;
+        }
+      });
     }
     retrieveInfo();
     return setResults([]);
   }, [props.url]);
-
-  // console.log(results);
-  // console.log(info[0].Name)
-
-  // .then((data) => console.log(results));
-
-  // console.log(randomArray)
-  // .then((info) => setResults(info));
-  // .then(response => setTitle({...response.Similar}))
-  // .then((data) => console.log(results));
-  //why is this happening twice?
-  // return (
-  //   <section>
-  //     <h4>Hi</h4>
-  //   </section>
-  // );
   if (!results.length || !info.length) {
     return (
       <section>
@@ -95,34 +40,45 @@ const TitlePage: React.FC<Props> = (props: Props) => {
       </section>
     );
   } else {
+    const allRelatedItems = results.map((item) => {
+      return <RelatedItem {...item} key={item.yID} />;
+    });
     return (
       <section className="title-page">
         <aside className="title-overview">
-          <h4>{info[0].Name}</h4>
+          <section className="title-header">
+            <h4>{info[0].Name}</h4>
+            <div className="title-favorite-button">
+              {/* this workaround is likely not accessible */}
+              <FavoriteButton
+                toggleFavorite={() =>
+                  props.toggleFavorite(`${info[0].Type}:${info[0].Name}`)
+                }
+                favorite={props.favorites.includes(
+                  `${info[0].Type}:${info[0].Name}`
+                )}
+              />
+            </div>
+          </section>
           <figure className="result-card-image-placeholder"></figure>
-          <a
-            href={info[0].yUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-          <img
-            className="youtube-link"
-            src="/images/youtube_logo.png"
-            alt="youtube-logo"
-          ></img>
+          <a href={info[0].yUrl} target="_blank" rel="noopener noreferrer">
+            <img
+              className="youtube-link"
+              src="/images/youtube_logo.png"
+              alt="youtube-logo"
+            ></img>
           </a>
         </aside>
         <main className="title-detailed-info">
           <p>{info[0].wTeaser}</p>
           <p className="wiki-link">
-            <a
-              href={info[0].wUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-            Read more...
+            <a href={info[0].wUrl} target="_blank" rel="noopener noreferrer">
+              Read more...
             </a>
           </p>
+            <h5>Related Items</h5>
+          <section className="all-related-items">
+            {allRelatedItems}</section>
         </main>
       </section>
     );

--- a/src/Components/TitlePage/TitlePage.tsx
+++ b/src/Components/TitlePage/TitlePage.tsx
@@ -48,7 +48,7 @@ const TitlePage: React.FC<Props> = (props: Props) => {
         <aside className="title-overview">
           <section className="title-header">
             <h4>{info[0].Name}</h4>
-            <div className="title-favorite-button">
+            {/* <div className="title-favorite-button"> */}
               {/* this workaround is likely not accessible */}
               <FavoriteButton
                 toggleFavorite={() =>
@@ -58,7 +58,7 @@ const TitlePage: React.FC<Props> = (props: Props) => {
                   `${info[0].Type}:${info[0].Name}`
                 )}
               />
-            </div>
+            {/* </div> */}
           </section>
           <figure className="result-card-image-placeholder"></figure>
           <a href={info[0].yUrl} target="_blank" rel="noopener noreferrer">

--- a/src/Components/TitlePage/TitlePage.tsx
+++ b/src/Components/TitlePage/TitlePage.tsx
@@ -2,40 +2,131 @@ import React, { useState, useEffect } from "react";
 import { searchResult } from "../../types";
 import "./TitlePage.css";
 // import youtube from '../../../public/images/youtube_logo.png'
+import { findTitleInfo } from "../../apiCalls";
+import { setConstantValue } from "typescript";
 
 interface Props {
-  item: searchResult;
+  // item?: searchResult;
+  url: string;
 }
 
+//I'm trying to make a fetch call
+//based on the url, I want to make a fetch call to that endpoint of the api
+//it should then display the appropriate information on the page
+//the title page is being run twice
+//my fetch call was being run twice, too
+//I don't know how to use useeffect effectively
+
+//why is the fetch call sending so many requests? It sends at least two no matter what I do.
+//I don't get why I can't seem to add the results of the fetch call to state
+//should I just save it in a variable?
+// const FavoritesList = (props: Props) => {
+//   const [results, setResults] = useState<searchResult[]>([]);
+
+//   useEffect(() => {
+//     async function fetchData() {
+//       const { Similar } = await fetchFavorites(props.favorites);
+
+//       if (Similar) setResults(Similar.Info);
+//     }
+//     fetchData();
+//   }, [props.favorites]);
+
+//normally I would do this in a separate file but handle in component did mount, I think
+//then I would pass down the information as a prop
+//I would invoke the function on page load?
+//that doesn't make sense
+
 const TitlePage: React.FC<Props> = (props: Props) => {
+  // debugger;
   // const actualTitle: string = props.name.split('+').join(' ')
-  // const [title, setTitle] = useState(actualTitle);
+  const [results, setResults] = useState<searchResult[]>([]); // const [info, setInfo] = useState([]);
+  const [info, setInfo] = useState<searchResult[]>([]); // const [info, setInfo] = useState([]);
   //don't need to set title
   //do I really need to set state?
   // setTitle(props.name.split('+').join(' '))
-  return (
-    <section className="title-page">
-      <aside className="title-overview">
-        <h4>{props.item.Name}</h4>
-        <figure className="result-card-image-placeholder"></figure>
-        <a href={props.item.yUrl} target="_blank" rel="noopener noreferrer">
+  console.log("happening");
+  //do fetch call here?
+  //props.name only exists...when?
+  //props.name exists if you are not coming from the search results
+  console.log(props.url);
+  // console.log(title)
+
+  // let results: {Results: object}[] = [];
+  // let info: {Info: object}[] = [];
+  useEffect(() => {
+    async function retrieveInfo() {
+      const allData = await findTitleInfo(props.url)
+        // .then((response) => (response.ok ? response.json() : null))
+        .then((data) => {
+          if (data) {
+            // results.push(data.Similar.Results);
+            // info.push(...data.Similar.Info)
+            setResults(data.Similar.Results);
+            setInfo(data.Similar.Info);
+            return data;
+            // console.log(data.Similar.Results)
+          }
+        });
+    }
+    retrieveInfo();
+    return setResults([]);
+  }, [props.url]);
+
+  // console.log(results);
+  // console.log(info[0].Name)
+
+  // .then((data) => console.log(results));
+
+  // console.log(randomArray)
+  // .then((info) => setResults(info));
+  // .then(response => setTitle({...response.Similar}))
+  // .then((data) => console.log(results));
+  //why is this happening twice?
+  // return (
+  //   <section>
+  //     <h4>Hi</h4>
+  //   </section>
+  // );
+  if (!results.length || !info.length) {
+    return (
+      <section>
+        <h5>Loading...</h5>
+      </section>
+    );
+  } else {
+    return (
+      <section className="title-page">
+        <aside className="title-overview">
+          <h4>{info[0].Name}</h4>
+          <figure className="result-card-image-placeholder"></figure>
+          <a
+            href={info[0].yUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
           <img
             className="youtube-link"
             src="/images/youtube_logo.png"
             alt="youtube-logo"
           ></img>
-        </a>
-      </aside>
-      <main className="title-detailed-info">
-        <p>{props.item.wTeaser}</p>
-        <p className="wiki-link">
-          <a href={props.item.wUrl} target="_blank" rel="noopener noreferrer">
-            Read more...
           </a>
-        </p>
-      </main>
-    </section>
-  );
+        </aside>
+        <main className="title-detailed-info">
+          <p>{info[0].wTeaser}</p>
+          <p className="wiki-link">
+            <a
+              href={info[0].wUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+            Read more...
+            </a>
+          </p>
+        </main>
+      </section>
+    );
+  }
 };
 
 export default TitlePage;

--- a/src/apiCalls.ts
+++ b/src/apiCalls.ts
@@ -8,6 +8,15 @@ export const findSimilar = async (term: string) => {
   return data;
 };
 
+export const findTitleInfo = async (term: string) => {
+  const corsAnywhere: string = `https://cors-anywhere.herokuapp.com/`;
+  const url = `${corsAnywhere}https://tastedive.com/api/similar?q=${term}&verbose=1&k=372838-DavePern-7J59GJ8D&limit=3`;
+  // const data = await fetch(url);
+  return await fetch(url)
+    .then((response) => response.json())
+    .catch((err) => console.log(err));
+};
+
 export const fetchFavorites = async (favorites: string[]) => {
   const corsAnywhere: string = `https://cors-anywhere.herokuapp.com/`;
   const media: string = favorites.join("%2C");


### PR DESCRIPTION
#### What's this PR do?
This PR updates the title page so that it's being generated using a fetch call. This means that title pages can be accessed even outside of a search. Titles correctly link to wikipedia, three related titles, and youtube. It generates a new component to allow the related items to display properly. 

#### Where should the reviewer start?
TitlePage.tsx and RelatedItem.tsx

#### How should this be manually tested?
This can be tested by running the application in the browser. 

#### Any background context you want to provide?
n/a
#### What are the relevant tickets?
Closes #5 
Opens #43, #44, and #45 

#### Screenshots (if appropriate)
n/a

#### Questions:
When I tried to implement a second fetch call within the TitlePage component in order to render the images, the application sent multiple network requests in a loop until the max number of requests per hour was reached. I'm not sure what was causing that problem so did not implement the image functionality for now. 
The favorite button works (although it refreshes the page), but I've noticed that neither the search image nor the favorites image are displaying properly from this page. 